### PR TITLE
fix ModuleNotFoundError: No module named 'common'

### DIFF
--- a/ch04/gradient_simplenet.py
+++ b/ch04/gradient_simplenet.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 import sys, os
 sys.path.append(os.pardir)  # 부모 디렉터리의 파일을 가져올 수 있도록 설정
+sys.path.append(os.path.abspath(os.path.join(__file__, '..', '..')))
+#print (os.path.abspath(os.path.join(__file__, '..', '..')))
+
 import numpy as np
 from common.functions import softmax, cross_entropy_error
 from common.gradient import numerical_gradient


### PR DESCRIPTION
Windows PC환경에서는 sys.path.append(os.pardir)  만으로는 ModuleNotFoundError에러가 발생함.
sys.path.append(os.path.abspath(os.path.join(__file__, '..', '..')))를 추가하여 해결가능합니다.